### PR TITLE
When an exception occurred in a step, set its report status appropriately

### DIFF
--- a/util/TestStep.js
+++ b/util/TestStep.js
@@ -32,9 +32,6 @@ class TestStep {
       } else {
         this.skip();
       }
-      await this.finish();
-      await KiteBaseTest.report.addStepReport(this.report.getJsonBuilder()); 
-
     } catch (error) {
       if(error instanceof KiteTestError) {
         console.log(error.message);
@@ -43,8 +40,10 @@ class TestStep {
         console.log(error);
         KiteBaseTest.report.status = Status.BROKEN;
       }
-
-    }
+      this.report.setStatus(KiteBaseTest.report.status);
+    } finally {
+      await this.finish();
+      await KiteBaseTest.report.addStepReport(this.report.getJsonBuilder()); 
   }
 
   /**


### PR DESCRIPTION
1, When a TestStep failed and threw an exception, set its reporting status to FAILED
2, Add step report to KiteBaseTest even when a step failed
This can make Allure report show right status of the failed step.