### PR TITLE
ChromeOptions: Fix check for window flags

### DIFF
--- a/wdmgmt/WebDriverUtility.js
+++ b/wdmgmt/WebDriverUtility.js
@@ -83,7 +83,7 @@ const getChromeOptions = function(capabilities) {
   if (capability.headless) {
     chromeOptions['args'].push('--headless');
   } else {
-		if (typeof capabilities.windowSize !== 'undefined' && capabilities.windowSize !== 'undefined') {
+		if (typeof capabilities.windowSize !== 'undefined' && typeof capabilities.windowSize !== 'undefined') {
 			chromeOptions['args'].push("--window-size=" + capabilities.windowSize);
 		}
   }


### PR DESCRIPTION
When I try to run the tests without this change, I get 
```org.openqa.selenium.WebDriverException: Error forwarding the new session Empty pool of VM for setup Capabilities```

@namvuCosmo 